### PR TITLE
Add Cloudflare RealtimeKit integration for Discuss calls

### DIFF
--- a/addons/mail_realtimekit/__init__.py
+++ b/addons/mail_realtimekit/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/mail_realtimekit/__manifest__.py
+++ b/addons/mail_realtimekit/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Mail RealtimeKit Integration",
+    "version": "1.0",
+    "summary": "Integrate Cloudflare RealtimeKit with Discuss calls",
+    "category": "Discuss",
+    "author": "Odoo Community",
+    "license": "LGPL-3",
+    "depends": ["mail"],
+    "data": [
+        "views/res_config_settings_views.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "mail_realtimekit/static/src/discuss/call/common/realtimekit_patch.js",
+        ],
+        "mail_realtimekit.assets_realtimekit": [
+            "mail_realtimekit/static/src/discuss/call/common/realtimekit_client.js",
+        ],
+    },
+}

--- a/addons/mail_realtimekit/models/__init__.py
+++ b/addons/mail_realtimekit/models/__init__.py
@@ -1,0 +1,5 @@
+from . import mail_ice_server
+from . import discuss_channel_member
+from . import discuss_channel
+from . import discuss_channel_rtc_session
+from . import res_config_settings

--- a/addons/mail_realtimekit/models/discuss_channel.py
+++ b/addons/mail_realtimekit/models/discuss_channel.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class DiscussChannel(models.Model):
+    _inherit = "discuss.channel"
+
+    realtimekit_session_token = fields.Char(groups="base.group_system")
+    realtimekit_session_expiration = fields.Datetime(groups="base.group_system")
+    realtimekit_session_metadata = fields.Text(groups="base.group_system")
+
+    def _clear_realtimekit_session(self):
+        self.write(
+            {
+                "realtimekit_session_token": False,
+                "realtimekit_session_expiration": False,
+                "realtimekit_session_metadata": False,
+                "sfu_channel_uuid": False,
+                "sfu_server_url": False,
+            }
+        )
+
+    def _is_realtimekit_session_valid(self):
+        self.ensure_one()
+        if not self.sfu_channel_uuid or not self.sfu_server_url or not self.realtimekit_session_token:
+            return False
+        if self.realtimekit_session_expiration and self.realtimekit_session_expiration <= fields.Datetime.now():
+            return False
+        return True

--- a/addons/mail_realtimekit/models/discuss_channel_member.py
+++ b/addons/mail_realtimekit/models/discuss_channel_member.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+import logging
+
+import requests
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields, models
+from odoo.tools import misc
+
+from odoo.addons.mail.models.discuss.discuss_channel_member import SFU_MODE_THRESHOLD
+
+_logger = logging.getLogger(__name__)
+
+
+class DiscussChannelMember(models.Model):
+    _inherit = "discuss.channel.member"
+
+    def _join_sfu(self, ice_servers=None):
+        config = self.env["ir.config_parameter"].sudo()
+        if not misc.str2bool(config.get_param("mail_realtimekit.enabled", "False")):
+            return super()._join_sfu(ice_servers)
+        for member in self:
+            member._join_realtimekit(config, ice_servers)
+
+    def _join_realtimekit(self, config, ice_servers=None):
+        if len(self.channel_id.rtc_session_ids) < SFU_MODE_THRESHOLD:
+            if self.channel_id.sfu_channel_uuid or self.channel_id.sfu_server_url:
+                self.channel_id._clear_realtimekit_session()
+                self.channel_id.rtc_session_ids._clear_realtimekit_credentials()
+            return
+        if self.channel_id._is_realtimekit_session_valid():
+            return
+        account_id = config.get_param("mail_realtimekit.account_id")
+        api_token = config.get_param("mail_realtimekit.api_token")
+        app_id = config.get_param("mail_realtimekit.app_id")
+        base_url = config.get_param("mail_realtimekit.api_base_url") or "https://api.cloudflare.com/client/v4"
+        endpoint_tpl = config.get_param("mail_realtimekit.session_endpoint")
+        if not endpoint_tpl:
+            if not account_id or not app_id:
+                _logger.warning("RealtimeKit session endpoint is not configured")
+                return
+            endpoint_tpl = "{base}/accounts/{account_id}/calls/apps/{app_id}/sessions"
+        endpoint = endpoint_tpl.format(base=base_url, account_id=account_id or "", app_id=app_id or "")
+        payload = {
+            "metadata": {
+                "channelId": self.channel_id.id,
+            }
+        }
+        payload_param = config.get_param("mail_realtimekit.session_payload")
+        if payload_param:
+            try:
+                payload.update(json.loads(payload_param))
+            except json.JSONDecodeError as error:
+                _logger.warning("Invalid JSON payload for RealtimeKit session request: %s", error)
+        headers = {"Authorization": f"Bearer {api_token}" if api_token else ""}
+        headers = {k: v for k, v in headers.items() if v}
+        headers.setdefault("Content-Type", "application/json")
+        try:
+            response = requests.post(endpoint, headers=headers, json=payload, timeout=10)
+        except requests.RequestException as error:
+            _logger.warning("Failed to create RealtimeKit session: %s", error)
+            return
+        if not response.ok:
+            _logger.warning(
+                "RealtimeKit session endpoint returned %(status)s: %(content)s",
+                {"status": response.status_code, "content": response.text},
+            )
+            return
+        try:
+            data = response.json()
+        except ValueError:
+            _logger.warning("RealtimeKit session endpoint returned invalid JSON: %s", response.text)
+            return
+        result = data.get("result") if isinstance(data, dict) else None
+        if isinstance(result, dict):
+            data = result
+        session_uuid = data.get("sessionId") or data.get("session_id") or data.get("uuid")
+        ws_url = data.get("wsUrl") or data.get("ws_url") or data.get("url")
+        token = data.get("token") or data.get("jwt") or data.get("jsonWebToken")
+        if not session_uuid or not ws_url or not token:
+            _logger.warning("RealtimeKit session response missing data: %s", data)
+            return
+        expires_at = data.get("expiresAt") or data.get("expires_at")
+        expires_in = data.get("expiresIn") or data.get("ttl")
+        expiration_dt = None
+        if expires_at:
+            try:
+                expiration_dt = fields.Datetime.to_datetime(expires_at)
+            except ValueError:
+                _logger.warning("RealtimeKit session expiration is invalid: %s", expires_at)
+        elif expires_in:
+            try:
+                expiration_dt = fields.Datetime.now() + relativedelta(seconds=int(expires_in))
+            except (TypeError, ValueError):
+                _logger.warning("RealtimeKit session TTL is invalid: %s", expires_in)
+        metadata = data.get("metadata") or {}
+        self.channel_id.write(
+            {
+                "sfu_channel_uuid": session_uuid,
+                "sfu_server_url": ws_url,
+                "realtimekit_session_token": token,
+                "realtimekit_session_expiration": expiration_dt,
+                "realtimekit_session_metadata": json.dumps(metadata) if metadata else False,
+            }
+        )
+        self.channel_id.rtc_session_ids._clear_realtimekit_credentials()
+        for session in self.channel_id.rtc_session_ids:
+            session._bus_send(
+                "discuss.channel.rtc.session/sfu_hot_swap",
+                {"serverInfo": self._get_rtc_server_info(session, ice_servers)},
+            )
+
+    def _get_rtc_server_info(self, rtc_session, ice_servers=None, key=None):
+        config = self.env["ir.config_parameter"].sudo()
+        if not misc.str2bool(config.get_param("mail_realtimekit.enabled", "False")):
+            return super()._get_rtc_server_info(rtc_session, ice_servers, key=key)
+        if not self.channel_id._is_realtimekit_session_valid():
+            self._join_realtimekit(config, ice_servers)
+        if not self.channel_id._is_realtimekit_session_valid():
+            return None
+        credentials = rtc_session._ensure_realtimekit_credentials()
+        if not credentials:
+            return None
+        server_info = {
+            "url": self.channel_id.sfu_server_url,
+            "channelUUID": self.channel_id.sfu_channel_uuid,
+            "jsonWebToken": credentials.get("token"),
+            "provider": "cloudflare",
+        }
+        metadata = self.channel_id.realtimekit_session_metadata
+        if metadata:
+            try:
+                server_info["metadata"] = json.loads(metadata)
+            except json.JSONDecodeError:
+                server_info["metadata"] = metadata
+        if credentials.get("client_id"):
+            server_info["clientId"] = credentials.get("client_id")
+        return server_info

--- a/addons/mail_realtimekit/models/discuss_channel_rtc_session.py
+++ b/addons/mail_realtimekit/models/discuss_channel_rtc_session.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+import logging
+
+import requests
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields, models
+from odoo.tools import misc
+
+_logger = logging.getLogger(__name__)
+
+
+class DiscussChannelRtcSession(models.Model):
+    _inherit = "discuss.channel.rtc.session"
+
+    realtimekit_client_token = fields.Char(groups="base.group_system")
+    realtimekit_client_id = fields.Char(groups="base.group_system")
+    realtimekit_token_expiration = fields.Datetime(groups="base.group_system")
+
+    def _clear_realtimekit_credentials(self):
+        self.write(
+            {
+                "realtimekit_client_token": False,
+                "realtimekit_client_id": False,
+                "realtimekit_token_expiration": False,
+            }
+        )
+
+    def _ensure_realtimekit_credentials(self):
+        config = self.env["ir.config_parameter"].sudo()
+        if not misc.str2bool(config.get_param("mail_realtimekit.enabled", "False")):
+            return None
+        self.ensure_one()
+        if not self.channel_id or not self.channel_id._is_realtimekit_session_valid():
+            return None
+        if (
+            self.realtimekit_client_token
+            and (not self.realtimekit_token_expiration or self.realtimekit_token_expiration > fields.Datetime.now())
+        ):
+            return {
+                "token": self.realtimekit_client_token,
+                "client_id": self.realtimekit_client_id,
+                "expires_at": self.realtimekit_token_expiration,
+            }
+        credentials = self._request_realtimekit_client_token(config)
+        if credentials:
+            self.write(
+                {
+                    "realtimekit_client_token": credentials.get("token"),
+                    "realtimekit_client_id": credentials.get("client_id"),
+                    "realtimekit_token_expiration": credentials.get("expires_at"),
+                }
+            )
+            return credentials
+        return None
+
+    def _request_realtimekit_client_token(self, config):
+        account_id = config.get_param("mail_realtimekit.account_id")
+        api_token = config.get_param("mail_realtimekit.api_token")
+        app_id = config.get_param("mail_realtimekit.app_id")
+        base_url = config.get_param("mail_realtimekit.api_base_url") or "https://api.cloudflare.com/client/v4"
+        endpoint_tpl = config.get_param("mail_realtimekit.client_endpoint")
+        if not endpoint_tpl:
+            if not account_id or not app_id:
+                _logger.warning("RealtimeKit client endpoint is not configured")
+                return None
+            endpoint_tpl = (
+                "{base}/accounts/{account_id}/calls/apps/{app_id}/sessions/{session_id}/clients"
+            )
+        endpoint = endpoint_tpl.format(
+            base=base_url,
+            account_id=account_id or "",
+            app_id=app_id or "",
+            session_id=self.channel_id.sfu_channel_uuid or "",
+        )
+        payload = {
+            "sessionId": self.channel_id.sfu_channel_uuid,
+            "metadata": {
+                "odooSessionId": self.id,
+                "channelId": self.channel_id.id,
+            },
+        }
+        payload_param = config.get_param("mail_realtimekit.client_payload")
+        if payload_param:
+            try:
+                payload.update(json.loads(payload_param))
+            except json.JSONDecodeError as error:
+                _logger.warning("Invalid JSON payload for RealtimeKit client request: %s", error)
+        headers = {"Authorization": f"Bearer {api_token}" if api_token else ""}
+        headers = {k: v for k, v in headers.items() if v}
+        headers.setdefault("Content-Type", "application/json")
+        try:
+            response = requests.post(endpoint, headers=headers, json=payload, timeout=10)
+        except requests.RequestException as error:
+            _logger.warning("Failed to obtain RealtimeKit client token: %s", error)
+            return None
+        if response.status_code == 401:
+            _logger.error("RealtimeKit client endpoint rejected credentials")
+            return None
+        if not response.ok:
+            _logger.warning(
+                "RealtimeKit client endpoint returned %(status)s: %(content)s",
+                {"status": response.status_code, "content": response.text},
+            )
+            return None
+        try:
+            data = response.json()
+        except ValueError:
+            _logger.warning("RealtimeKit client endpoint returned invalid JSON: %s", response.text)
+            return None
+        result = data.get("result") if isinstance(data, dict) else None
+        if isinstance(result, dict):
+            data = result
+        token = data.get("token") or data.get("jwt") or data.get("jsonWebToken")
+        if not token:
+            _logger.warning("RealtimeKit client token is missing from response: %s", data)
+            return None
+        expires_at = data.get("expiresAt") or data.get("expires_at")
+        expires_in = data.get("expiresIn") or data.get("ttl")
+        expiration_dt = None
+        if expires_at:
+            try:
+                expiration_dt = fields.Datetime.to_datetime(expires_at)
+            except ValueError:
+                _logger.warning("RealtimeKit client expiration is invalid: %s", expires_at)
+        elif expires_in:
+            try:
+                expiration_dt = fields.Datetime.now() + relativedelta(seconds=int(expires_in))
+            except (TypeError, ValueError):
+                _logger.warning("RealtimeKit client TTL is invalid: %s", expires_in)
+        return {
+            "token": token,
+            "client_id": data.get("clientId") or data.get("client_id"),
+            "expires_at": expiration_dt,
+        }
+
+    def action_disconnect(self):
+        config = self.env["ir.config_parameter"].sudo()
+        if misc.str2bool(config.get_param("mail_realtimekit.enabled", "False")):
+            self._disconnect_realtimekit_clients(config)
+        return super().action_disconnect()
+
+    def _disconnect_realtimekit_clients(self, config):
+        account_id = config.get_param("mail_realtimekit.account_id")
+        api_token = config.get_param("mail_realtimekit.api_token")
+        app_id = config.get_param("mail_realtimekit.app_id")
+        base_url = config.get_param("mail_realtimekit.api_base_url") or "https://api.cloudflare.com/client/v4"
+        endpoint_tpl = config.get_param("mail_realtimekit.client_disconnect_endpoint")
+        if not endpoint_tpl:
+            if not account_id or not app_id:
+                return
+            endpoint_tpl = (
+                "{base}/accounts/{account_id}/calls/apps/{app_id}/sessions/{session_id}/clients/{client_id}"
+            )
+        headers = {"Authorization": f"Bearer {api_token}" if api_token else ""}
+        headers = {k: v for k, v in headers.items() if v}
+        for session in self:
+            if not session.realtimekit_client_id or not session.channel_id.sfu_channel_uuid:
+                continue
+            endpoint = endpoint_tpl.format(
+                base=base_url,
+                account_id=account_id or "",
+                app_id=app_id or "",
+                session_id=session.channel_id.sfu_channel_uuid,
+                client_id=session.realtimekit_client_id,
+            )
+            try:
+                response = requests.delete(endpoint, headers=headers, timeout=5)
+            except requests.RequestException:
+                continue
+            if not response.ok and response.status_code not in (404, 410):
+                _logger.debug(
+                    "RealtimeKit failed to disconnect client %(client)s (%(status)s)",
+                    {"client": session.realtimekit_client_id, "status": response.status_code},
+                )
+            session._clear_realtimekit_credentials()

--- a/addons/mail_realtimekit/models/mail_ice_server.py
+++ b/addons/mail_realtimekit/models/mail_ice_server.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+import logging
+
+import requests
+
+from odoo import _, models
+from odoo.exceptions import UserError
+from odoo.tools import misc
+
+_logger = logging.getLogger(__name__)
+
+
+class MailIceServerRealtimeKit(models.Model):
+    _inherit = "mail.ice.server"
+
+    def _get_realtimekit_ice_servers(self):
+        config = self.env["ir.config_parameter"].sudo()
+        if not misc.str2bool(config.get_param("mail_realtimekit.enabled", "False")):
+            return None
+        account_id = config.get_param("mail_realtimekit.account_id")
+        api_token = config.get_param("mail_realtimekit.api_token")
+        app_id = config.get_param("mail_realtimekit.app_id")
+        base_url = config.get_param("mail_realtimekit.api_base_url") or "https://api.cloudflare.com/client/v4"
+        endpoint_tpl = config.get_param("mail_realtimekit.turn_endpoint")
+        if not endpoint_tpl:
+            if not account_id:
+                _logger.warning("RealtimeKit TURN endpoint is not configured")
+                return None
+            template = "{base}/accounts/{account_id}/calls"
+            if app_id:
+                template += "/apps/{app_id}"
+            endpoint_tpl = template + "/sessions/turn"
+        endpoint = endpoint_tpl.format(base=base_url, account_id=account_id or "", app_id=app_id or "")
+        headers = {"Authorization": f"Bearer {api_token}" if api_token else ""}
+        headers = {k: v for k, v in headers.items() if v}
+        headers.setdefault("Content-Type", "application/json")
+        payload = {}
+        ttl = config.get_param("mail_realtimekit.turn_ttl")
+        if ttl:
+            try:
+                payload["ttl"] = int(ttl)
+            except ValueError:
+                _logger.warning("Invalid RealtimeKit TURN TTL '%s'", ttl)
+        payload_param = config.get_param("mail_realtimekit.turn_payload")
+        if payload_param:
+            try:
+                payload.update(json.loads(payload_param))
+            except json.JSONDecodeError as error:
+                _logger.warning("Invalid JSON payload for RealtimeKit TURN request: %s", error)
+        try:
+            response = requests.post(endpoint, headers=headers, json=payload or None, timeout=10)
+        except requests.RequestException as error:
+            _logger.warning("Failed to obtain TURN credentials from Cloudflare RealtimeKit: %s", error)
+            return None
+        if response.status_code == 401:
+            raise UserError(_("Cloudflare RealtimeKit credentials are invalid."))
+        if not response.ok:
+            _logger.warning(
+                "RealtimeKit TURN endpoint returned %(status)s: %(content)s",
+                {"status": response.status_code, "content": response.text},
+            )
+            return None
+        try:
+            data = response.json()
+        except ValueError:
+            _logger.warning("RealtimeKit TURN endpoint returned invalid JSON: %s", response.text)
+            return None
+        result = data.get("result") if isinstance(data, dict) else None
+        ice_servers = None
+        if isinstance(result, dict):
+            ice_servers = result.get("iceServers") or result.get("ice_servers")
+        if ice_servers is None and isinstance(data, dict):
+            ice_servers = data.get("iceServers") or data.get("ice_servers")
+        if not ice_servers:
+            _logger.warning("RealtimeKit TURN endpoint did not return any ICE server: %s", data)
+            return None
+        return ice_servers
+
+    def _get_ice_servers(self):
+        realtimekit_servers = self._get_realtimekit_ice_servers()
+        if realtimekit_servers:
+            return realtimekit_servers
+        return super()._get_ice_servers()

--- a/addons/mail_realtimekit/models/res_config_settings.py
+++ b/addons/mail_realtimekit/models/res_config_settings.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    mail_realtimekit_enabled = fields.Boolean(string="Use Cloudflare RealtimeKit", config_parameter="mail_realtimekit.enabled")
+    mail_realtimekit_account_id = fields.Char(string="Cloudflare account ID", config_parameter="mail_realtimekit.account_id")
+    mail_realtimekit_app_id = fields.Char(string="RealtimeKit application ID", config_parameter="mail_realtimekit.app_id")
+    mail_realtimekit_api_token = fields.Char(string="RealtimeKit API token", config_parameter="mail_realtimekit.api_token")
+    mail_realtimekit_api_base_url = fields.Char(
+        string="RealtimeKit API base URL", default="https://api.cloudflare.com/client/v4",
+        config_parameter="mail_realtimekit.api_base_url",
+    )
+    mail_realtimekit_session_endpoint = fields.Char(
+        string="Session endpoint template", config_parameter="mail_realtimekit.session_endpoint",
+        help="Template used to provision a RealtimeKit session. The placeholders {base}, {account_id} and {app_id} are replaced automatically.",
+    )
+    mail_realtimekit_session_payload = fields.Text(
+        string="Session payload", config_parameter="mail_realtimekit.session_payload",
+        help="Optional JSON payload merged with the default session request.",
+    )
+    mail_realtimekit_client_endpoint = fields.Char(
+        string="Client endpoint template", config_parameter="mail_realtimekit.client_endpoint",
+        help="Template used to request client tokens. Supports {base}, {account_id}, {app_id} and {session_id} placeholders.",
+    )
+    mail_realtimekit_client_payload = fields.Text(
+        string="Client payload", config_parameter="mail_realtimekit.client_payload",
+        help="Optional JSON payload merged with the default client request.",
+    )
+    mail_realtimekit_turn_endpoint = fields.Char(
+        string="TURN endpoint template", config_parameter="mail_realtimekit.turn_endpoint",
+        help="Template used to request TURN credentials. Supports {base}, {account_id} and {app_id} placeholders.",
+    )
+    mail_realtimekit_turn_payload = fields.Text(
+        string="TURN payload", config_parameter="mail_realtimekit.turn_payload",
+        help="Optional JSON payload appended to the TURN request.",
+    )
+    mail_realtimekit_turn_ttl = fields.Char(
+        string="TURN TTL", config_parameter="mail_realtimekit.turn_ttl",
+        help="Optional TTL passed to the TURN credential endpoint.",
+    )
+    mail_realtimekit_client_disconnect_endpoint = fields.Char(
+        string="Disconnect endpoint template", config_parameter="mail_realtimekit.client_disconnect_endpoint",
+        help="Endpoint used to disconnect clients. Supports {base}, {account_id}, {app_id}, {session_id} and {client_id} placeholders.",
+    )

--- a/addons/mail_realtimekit/static/src/discuss/call/common/realtimekit_client.js
+++ b/addons/mail_realtimekit/static/src/discuss/call/common/realtimekit_client.js
@@ -1,0 +1,154 @@
+/** @odoo-module **/
+
+export const SFU_CLIENT_STATE = {
+    DISCONNECTED: "DISCONNECTED",
+    CONNECTING: "CONNECTING",
+    AUTHENTICATED: "AUTHENTICATED",
+    CONNECTED: "CONNECTED",
+    CLOSED: "CLOSED",
+};
+
+const DEFAULT_TIMEOUT = 10000;
+
+export class RealtimeKitClient extends EventTarget {
+    errors = [];
+
+    constructor() {
+        super();
+        this._state = SFU_CLIENT_STATE.DISCONNECTED;
+        this._socket = undefined;
+        this._url = undefined;
+        this._token = undefined;
+        this._options = undefined;
+        this._timeout = undefined;
+    }
+
+    set state(state) {
+        if (state === this._state) {
+            return;
+        }
+        this._state = state;
+        this.dispatchEvent(new CustomEvent("stateChange", { detail: { state } }));
+    }
+
+    get state() {
+        return this._state;
+    }
+
+    broadcast(message) {
+        this._send({ type: "broadcast", payload: message });
+    }
+
+    async connect(url, token, options = {}) {
+        this._url = url.replace(/^http/, "ws");
+        this._token = token;
+        this._options = options;
+        this.state = SFU_CLIENT_STATE.CONNECTING;
+        return new Promise((resolve, reject) => {
+            try {
+                this._socket = new WebSocket(this._url);
+            } catch (error) {
+                this.state = SFU_CLIENT_STATE.CLOSED;
+                reject(error);
+                return;
+            }
+            const handleFailure = (error) => {
+                clearTimeout(this._timeout);
+                if (this.state !== SFU_CLIENT_STATE.CLOSED) {
+                    this.state = SFU_CLIENT_STATE.CLOSED;
+                }
+                reject(error instanceof Event ? new Error("RealtimeKit connection failed") : error);
+            };
+            this._socket.addEventListener("open", () => {
+                clearTimeout(this._timeout);
+                this.state = SFU_CLIENT_STATE.AUTHENTICATED;
+                this._send({
+                    type: "authenticate",
+                    token: this._token,
+                    sessionId: this._options.channelUUID,
+                    clientId: this._options.clientId,
+                    metadata: this._options.metadata,
+                });
+            });
+            this._socket.addEventListener("message", (event) => {
+                const payload = this._parse(event.data);
+                if (!payload) {
+                    return;
+                }
+                switch (payload.type) {
+                    case "ready":
+                    case "connected":
+                        this.state = SFU_CLIENT_STATE.CONNECTED;
+                        resolve();
+                        return;
+                    case "authenticated":
+                        this.state = SFU_CLIENT_STATE.AUTHENTICATED;
+                        return;
+                    case "broadcast":
+                    case "connection_change":
+                    case "disconnect":
+                    case "info_change":
+                    case "track":
+                        this.dispatchEvent(new CustomEvent("update", { detail: { name: payload.type, payload } }));
+                        return;
+                    case "error":
+                        this.errors.push(payload);
+                        handleFailure(new Error(payload.message || "RealtimeKit error"));
+                        return;
+                }
+            });
+            this._socket.addEventListener("close", (event) => {
+                clearTimeout(this._timeout);
+                if (this.state !== SFU_CLIENT_STATE.CLOSED) {
+                    this.state = SFU_CLIENT_STATE.CLOSED;
+                    this.dispatchEvent(new CustomEvent("stateChange", { detail: { state: this.state, cause: event.code } }));
+                }
+            });
+            this._socket.addEventListener("error", handleFailure);
+            this._timeout = setTimeout(() => handleFailure(new Error("RealtimeKit handshake timeout")), DEFAULT_TIMEOUT);
+        });
+    }
+
+    disconnect() {
+        if (this._socket) {
+            this._socket.close();
+            this._socket = undefined;
+        }
+        this.state = SFU_CLIENT_STATE.DISCONNECTED;
+    }
+
+    async updateUpload(type, track) {
+        this._send({ type: "upload", payload: { media: type, active: Boolean(track) } });
+    }
+
+    updateDownload(sessionId, states) {
+        this._send({ type: "download", payload: { sessionId, states } });
+    }
+
+    updateInfo(info, options = {}) {
+        this._send({ type: "info", payload: { info, options } });
+    }
+
+    _send(message) {
+        if (!this._socket || this._socket.readyState !== WebSocket.OPEN) {
+            return;
+        }
+        try {
+            this._socket.send(JSON.stringify(message));
+        } catch (error) {
+            this.errors.push(error);
+        }
+    }
+
+    _parse(raw) {
+        if (!raw) {
+            return null;
+        }
+        try {
+            return JSON.parse(raw);
+        } catch (error) {
+            this.errors.push(error);
+            return null;
+        }
+    }
+}

--- a/addons/mail_realtimekit/static/src/discuss/call/common/realtimekit_patch.js
+++ b/addons/mail_realtimekit/static/src/discuss/call/common/realtimekit_patch.js
@@ -1,0 +1,72 @@
+/** @odoo-module **/
+
+import { RtcService, CONNECTION_TYPES } from "@mail/discuss/call/common/rtc_service";
+import { memoize } from "@web/core/utils/functions";
+import { loadBundle } from "@web/core/assets";
+import { patch } from "@web/core/utils/patch";
+import { browser } from "@web/core/browser/browser";
+
+const loadRealtimeKitAssets = memoize(async () => {
+    await loadBundle("mail_realtimekit.assets_realtimekit");
+    return odoo.loader.modules.get("@mail_realtimekit/discuss/call/common/realtimekit_client");
+});
+
+patch(RtcService.prototype, "mail_realtimekit.load_sfu", {
+    async _loadSfu(...args) {
+        if (this.serverInfo?.provider === "cloudflare") {
+            const load = async () => {
+                const module = await loadRealtimeKitAssets();
+                this.SFU_CLIENT_STATE = module.SFU_CLIENT_STATE;
+                this.sfuClient = new module.RealtimeKitClient();
+            };
+            try {
+                await load();
+            } catch (error) {
+                await new Promise((resolve, reject) => {
+                    setTimeout(async () => {
+                        try {
+                            await load();
+                        } catch (retryError) {
+                            reject(retryError);
+                            return;
+                        }
+                        resolve();
+                    }, 1000);
+                });
+            }
+            return;
+        }
+        return this._super(...args);
+    },
+});
+
+patch(RtcService.prototype, "mail_realtimekit.call", {
+    async call({ asFallback = false } = {}) {
+        if (this.serverInfo?.provider !== "cloudflare") {
+            return this._super({ asFallback });
+        }
+        if (asFallback && !this.state.fallbackMode) {
+            return;
+        }
+        if (this.state.connectionType === CONNECTION_TYPES.SERVER) {
+            if (this.sfuClient.state === this.SFU_CLIENT_STATE.DISCONNECTED) {
+                browser.clearTimeout(this.sfuTimeout);
+                this.sfuTimeout = browser.setTimeout(() => {
+                    this.log(this.selfSession, "sfu connection timeout", { important: true });
+                    this._downgradeConnection();
+                }, 10000);
+                await this.sfuClient.connect(this.serverInfo.url, this.serverInfo.jsonWebToken, {
+                    channelUUID: this.serverInfo.channelUUID,
+                    clientId: this.serverInfo.clientId,
+                    metadata: this.serverInfo.metadata,
+                    iceServers: this.serverInfo.iceServers || this.iceServers,
+                });
+            }
+            return;
+        }
+        if (this.state.channel.rtcSessions.length === 0) {
+            return;
+        }
+        return this._super({ asFallback });
+    },
+});

--- a/addons/mail_realtimekit/views/res_config_settings_views.xml
+++ b/addons/mail_realtimekit/views/res_config_settings_views.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form_mail_realtimekit" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.mail.realtimekit</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="mail.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='rtc_settings']" position="inside">
+                <div class="row mt16">
+                    <div class="col-12 col-lg-6">
+                        <h3>Cloudflare RealtimeKit</h3>
+                        <div class="o_form_label o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="mail_realtimekit_enabled"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="mail_realtimekit_enabled"/>
+                                <div class="text-muted">
+                                    Enable Cloudflare RealtimeKit to provision calls and TURN credentials for Discuss.
+                                </div>
+                            </div>
+                        </div>
+                        <div class="o_setting_box" attrs="{'invisible': [('mail_realtimekit_enabled', '=', False)]}">
+                            <div class="o_setting_left_pane"></div>
+                            <div class="o_setting_right_pane">
+                                <div class="row g-3">
+                                    <div class="col-12">
+                                        <label for="mail_realtimekit_account_id"/>
+                                        <field name="mail_realtimekit_account_id" class="w-100"/>
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="mail_realtimekit_app_id"/>
+                                        <field name="mail_realtimekit_app_id" class="w-100"/>
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="mail_realtimekit_api_token"/>
+                                        <field name="mail_realtimekit_api_token" password="True" class="w-100"/>
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="mail_realtimekit_api_base_url"/>
+                                        <field name="mail_realtimekit_api_base_url" class="w-100"/>
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="mail_realtimekit_session_endpoint"/>
+                                        <field name="mail_realtimekit_session_endpoint" placeholder="{base}/accounts/{account_id}/calls/apps/{app_id}/sessions" class="w-100"/>
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="mail_realtimekit_session_payload"/>
+                                        <field name="mail_realtimekit_session_payload" placeholder='{"type": "sfu"}' class="w-100" widget="text"/>
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="mail_realtimekit_client_endpoint"/>
+                                        <field name="mail_realtimekit_client_endpoint" placeholder="{base}/accounts/{account_id}/calls/apps/{app_id}/sessions/{session_id}/clients" class="w-100"/>
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="mail_realtimekit_client_payload"/>
+                                        <field name="mail_realtimekit_client_payload" class="w-100" widget="text"/>
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="mail_realtimekit_turn_endpoint"/>
+                                        <field name="mail_realtimekit_turn_endpoint" placeholder="{base}/accounts/{account_id}/calls/apps/{app_id}/sessions/turn" class="w-100"/>
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="mail_realtimekit_turn_ttl"/>
+                                        <field name="mail_realtimekit_turn_ttl" class="w-100"/>
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="mail_realtimekit_turn_payload"/>
+                                        <field name="mail_realtimekit_turn_payload" class="w-100" widget="text"/>
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="mail_realtimekit_client_disconnect_endpoint"/>
+                                        <field name="mail_realtimekit_client_disconnect_endpoint" placeholder="{base}/accounts/{account_id}/calls/apps/{app_id}/sessions/{session_id}/clients/{client_id}" class="w-100"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add a dedicated `mail_realtimekit` addon that provisions ICE, SFU sessions and per-client tokens from Cloudflare RealtimeKit for Discuss calls
- expose Cloudflare configuration options in settings and extend Discuss to store RealtimeKit session metadata
- patch the Discuss RTC frontend to lazy load a RealtimeKit client and connect with Cloudflare-provided credentials

## Testing
- python3 -m compileall addons/mail_realtimekit

------
https://chatgpt.com/codex/tasks/task_e_68d58bb06e5083318b66e14da3858316